### PR TITLE
Declare variables before to support OUT in C# 6.0.

### DIFF
--- a/RenumberNavObjectIds/Program.cs
+++ b/RenumberNavObjectIds/Program.cs
@@ -30,6 +30,9 @@ namespace RenumberNavObjectIds
 
             if (!string.IsNullOrEmpty(options.FromObjectId) || !string.IsNullOrEmpty(options.ToObjectId) || !string.IsNullOrEmpty(options.NoOfObjects))
             {
+                int from;
+                int to;
+                int count;
 
                 if (int.TryParse(options.FromObjectId, out from) && int.TryParse(options.ToObjectId, out to) && int.TryParse(options.NoOfObjects, out count))
                 {

--- a/RenumberNavObjectIds/Program.cs
+++ b/RenumberNavObjectIds/Program.cs
@@ -30,7 +30,8 @@ namespace RenumberNavObjectIds
 
             if (!string.IsNullOrEmpty(options.FromObjectId) || !string.IsNullOrEmpty(options.ToObjectId) || !string.IsNullOrEmpty(options.NoOfObjects))
             {
-                if (int.TryParse(options.FromObjectId, out int from) && int.TryParse(options.ToObjectId, out int to) && int.TryParse(options.NoOfObjects, out int count))
+
+                if (int.TryParse(options.FromObjectId, out from) && int.TryParse(options.ToObjectId, out to) && int.TryParse(options.NoOfObjects, out count))
                 {
                     try
                     {


### PR DESCRIPTION
I`ve just opened the project in VS2013 (also have 2015 but the version selector picked VS2013 automatically) and saw compilation errors related to using declaring OUT variables in a function call. This is supported with C# 7.0 I think but before this was not possible (I maybe it was in a C# 6.0 preview but later it was removed).

I add it as a proposal to gain compatibility with the previous versions.